### PR TITLE
Handle optional Kubernetes inputs 

### DIFF
--- a/backend/src/v2/driver/k8s_test.go
+++ b/backend/src/v2/driver/k8s_test.go
@@ -1921,6 +1921,42 @@ func Test_extendPodSpecPatch_Tolerations(t *testing.T) {
 				"param_1": validListOfStructsOrPanic([]map[string]interface{}{}),
 			},
 		},
+		{
+			"Valid - toleration json - list of json strings",
+			&kubernetesplatform.KubernetesExecutorConfig{
+				Tolerations: []*kubernetesplatform.Toleration{
+					{
+						TolerationJson: inputParamComponent("param_1"),
+					},
+				},
+			},
+			&k8score.PodSpec{
+				Containers: []k8score.Container{
+					{
+						Name: "main",
+					},
+				},
+				Tolerations: []k8score.Toleration{
+					{
+						Key:      "key1",
+						Operator: "Equal",
+						Value:    "value1",
+						Effect:   "NoSchedule",
+					},
+					{
+						Key:      "key2",
+						Operator: "Exists",
+						Effect:   "NoExecute",
+					},
+				},
+			},
+			map[string]*structpb.Value{
+				"param_1": validListOfJSONStringsOrPanic([]string{
+					`{"key":"key1","operator":"Equal","value":"value1","effect":"NoSchedule"}`,
+					`{"key":"key2","operator":"Exists","effect":"NoExecute"}`,
+				}),
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -2892,6 +2928,14 @@ func validListOfStructsOrPanic(data []map[string]interface{}) *structpb.Value {
 			panic(err)
 		}
 		listValues = append(listValues, structpb.NewStructValue(s))
+	}
+	return structpb.NewListValue(&structpb.ListValue{Values: listValues})
+}
+
+func validListOfJSONStringsOrPanic(data []string) *structpb.Value {
+	listValues := make([]*structpb.Value, 0, len(data))
+	for _, item := range data {
+		listValues = append(listValues, structpb.NewStringValue(item))
 	}
 	return structpb.NewListValue(&structpb.ListValue{Values: listValues})
 }


### PR DESCRIPTION
**Description of your changes:**
-Follow-up work on optional Kubernetes runtime handling after refinement in PR #12399, which itself corrected the original removal in PR #12377.
-This change updates the v2 driver so that all optional Kubernetes executor inputs (config maps, secrets, image pull secrets, tolerations) are gracefully ignored when users provide them as empty strings or JSON strings via the CLI/UI. 

**Highlights:**
-Normalize string-valued parameters and skip appending volumes/env/pull secrets when the resolved value is "" or whitespace.
-Extend toleration handling to accept both struct and string representations while skipping null/empty entries.
-Add unit coverage for mixed toleration cases and string-based inputs.
-With this fix, runs like missing_kubernetes_optional_inputs succeed both when users supply real values and when they leave all optional parameters blank, and the generated Argo pod spec no longer contains invalid resource names.

